### PR TITLE
Normalize Apache License 2.0 identifier

### DIFF
--- a/beluga_demo_bearing_localization/package.xml
+++ b/beluga_demo_bearing_localization/package.xml
@@ -5,7 +5,7 @@
   <version>1.0.0</version>
   <description> TBD </description>
   <maintainer email="glpuga@ekumenlabs.com">Gerardo Puga</maintainer>
-  <license>Apache 2.0</license>
+  <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/beluga_demo_bringup/package.xml
+++ b/beluga_demo_bringup/package.xml
@@ -5,7 +5,7 @@
   <version>1.0.0</version>
   <description> TBD </description>
   <maintainer email="glpuga@ekumenlabs.com">Gerardo Puga</maintainer>
-  <license>Apache 2.0</license>
+  <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/beluga_demo_description/package.xml
+++ b/beluga_demo_description/package.xml
@@ -5,7 +5,7 @@
   <version>1.0.0</version>
   <description> TBD </description>
   <maintainer email="glpuga@ekumenlabs.com">Gerardo Puga</maintainer>
-  <license>Apache 2.0</license>
+  <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/beluga_demo_fiducials_localization/package.xml
+++ b/beluga_demo_fiducials_localization/package.xml
@@ -5,7 +5,7 @@
   <version>1.0.0</version>
   <description> TBD </description>
   <maintainer email="glpuga@ekumenlabs.com">Gerardo Puga</maintainer>
-  <license>Apache 2.0</license>
+  <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/beluga_demo_gazebo/package.xml
+++ b/beluga_demo_gazebo/package.xml
@@ -5,7 +5,7 @@
   <version>1.0.0</version>
   <description> TBD </description>
   <maintainer email="glpuga@ekumenlabs.com">Gerardo Puga</maintainer>
-  <license>TBD</license>
+  <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/beluga_demo_lidar_localization/package.xml
+++ b/beluga_demo_lidar_localization/package.xml
@@ -5,7 +5,7 @@
   <version>1.0.0</version>
   <description> TBD </description>
   <maintainer email="glpuga@ekumenlabs.com">Gerardo Puga</maintainer>
-  <license>Apache 2.0</license>
+  <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/beluga_demo_rviz2/package.xml
+++ b/beluga_demo_rviz2/package.xml
@@ -5,7 +5,7 @@
   <version>1.0.0</version>
   <description> TBD </description>
   <maintainer email="glpuga@ekumenlabs.com">Gerardo Puga</maintainer>
-  <license>Apache 2.0</license>
+  <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/beluga_demo_teleop/package.xml
+++ b/beluga_demo_teleop/package.xml
@@ -5,7 +5,7 @@
   <version>1.0.0</version>
   <description> TBD </description>
   <maintainer email="glpuga@ekumenlabs.com">Gerardo Puga</maintainer>
-  <license>Apache 2.0</license>
+  <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 


### PR DESCRIPTION
To match the full name as specified by [SPDX](https://spdx.org/licenses/Apache-2.0.html).