### PR TITLE
Fix amcl3_localization demo not building

### DIFF
--- a/localization/beluga_demo_amcl3_localization/CMakeLists.txt
+++ b/localization/beluga_demo_amcl3_localization/CMakeLists.txt
@@ -114,7 +114,7 @@ install(PROGRAMS
 )
 
 install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
-install(DIRECTORY maps DESTINATION share/${PROJECT_NAME})
+install(DIRECTORY maps DESTINATION share/${PROJECT_NAME} OPTIONAL)
 install(DIRECTORY rviz DESTINATION share/${PROJECT_NAME})
 
 ament_package()


### PR DESCRIPTION
Small fix to a problem spotted after cloning the repo from scratch. If you try to build all demos using the alias `demo_build`, you get an error in `amcl3_localization` package:

```
--- stderr: beluga_demo_amcl3_localization                             
CMake Error at ament_cmake_symlink_install/ament_cmake_symlink_install.cmake:100 (message):
  ament_cmake_symlink_install_directory() can't find
  '/home/developer/ws/src/beluga_demo/localization/beluga_demo_amcl3_localization/maps'
Call Stack (most recent call first):
  ament_cmake_symlink_install/ament_cmake_symlink_install.cmake:329 (ament_cmake_symlink_install_directory)
  cmake_install.cmake:46 (include)


---
Failed   <<< beluga_demo_amcl3_localization [1.15s, exited with code 1]
```

After checking it, it seems that the `maps` directory is missing for this demo, and it should have been pushed at some time. Removing the symlink from the CMakeLists.txt file solves the error, being able to build the package, but still not being able to execute the demo, as a file is missing (`map_1005_07.vdb`):

```
[beluga_amcl3_demo_node-5] terminate called after throwing an instance of 'openvdb::v8_2::IoError'
[beluga_amcl3_demo_node-5]   what():  IoError: could not get size of file /home/developer/ws/install/beluga_demo_amcl3_localization/share/beluga_demo_amcl3_localization/maps/map_1005_07.vdb (No such file or directory)
[ERROR] [beluga_amcl3_demo_node-5]: process has died [pid 14365, exit code -6, cmd '/home/developer/ws/install/beluga_demo_amcl3_localization/lib/beluga_demo_amcl3_localization/beluga_amcl3_demo_node --ros-args -r __node:=beluga_amcl3_demo --params-file /tmp/launch_params_i06_xkhz'].
```

This fix at least avoids other users to have problems with this demo if they are building all available demos.