### PR TITLE
Add `apriltag_ros` as fiducial demo dependency

### DIFF
--- a/localization/beluga_demo_fiducial_localization/package.xml
+++ b/localization/beluga_demo_fiducial_localization/package.xml
@@ -23,6 +23,7 @@
   <depend>beluga</depend>
   <depend>beluga_ros</depend>
 
+  <depend>apriltag_ros</depend>
   <depend>beluga_april_tag_adapter</depend>
   <depend>beluga_april_tag_adapter_msgs</depend>
   <depend>beluga_feature_map_server</depend>


### PR DESCRIPTION
Precisely what the title says. Lacking the dependency, `colcon build --packages-up-to ...` would not pick up the former.